### PR TITLE
Fix plugins.xml install path

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -101,7 +101,7 @@ install(DIRECTORY include/${PROJECT_NAME}/
   FILES_MATCHING PATTERN "*.h")
 
 install(FILES plugins/nodelet_plugins.xml
-  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})
+  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/plugins)
 
 foreach(dir launch urdf include/shaders)
    install(DIRECTORY ${dir}/


### PR DESCRIPTION
Solves

`Skipped loading plugin with error: XML Document '/opt/ros/melodic/share/realtime_urdf_filter/plugins/nodelet_plugins.xml' has no Root Element. This likely means the XML is malformed or missing..`